### PR TITLE
Regression testing, CI and Conda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ driver_functions_Floodplains-Terraces/build/Makefile
 driver_functions_Floodplains-Terraces/build/cmake_install.cmake
 boost/*
 build/*
+tests/results/*
+.pytest_cache
+.cache
+__pycache__
+tests/fixtures/*.hdr
+tests/fixtures/*.bil

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,13 +35,14 @@ install:
 # Activate the venv and run a driver
 script:
   - source activate lsdtt
+  - cd ..
   - cd tests/
   - mkdir results
   - cd fixtures
   - wget https://github.com/LSDtopotools/ExampleTopoDatasets/raw/master/coweeta.bil
-  - wget wget https://github.com/LSDtopotools/ExampleTopoDatasets/raw/master/coweeta.hdr
-  -
-  -
+  - wget https://github.com/LSDtopotools/ExampleTopoDatasets/raw/master/coweeta.hdr
+  - wget https://github.com/LSDtopotools/RegressionData/raw/master/coweeta_output_SLOPE.bil
+  - wget https://github.com/LSDtopotools/RegressionData/raw/master/coweeta_output_SLOPE.hdr
   - cd ..
   - LSDTT_BasicMetrics fixtures/ coweeta.driver
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ script:
   - cd conda-recipe
   - conda build lsdtopotools -c conda-forge
   - conda create -n lsdtt lsdtopotools -c conda-forge --use-local
+  - conda activate lsdtt
   - LSDTT_BasicMetrics
 
 # script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,11 +44,25 @@ script:
   - cd fixtures
   - wget https://github.com/LSDtopotools/ExampleTopoDatasets/raw/master/coweeta.bil
   - wget https://github.com/LSDtopotools/ExampleTopoDatasets/raw/master/coweeta.hdr
+  - wget https://github.com/LSDtopotools/RegressionData/raw/master/coweeta_output_ASPECT.bil
+  - wget https://github.com/LSDtopotools/RegressionData/raw/master/coweeta_output_ASPECT.hdr
+  - wget https://github.com/LSDtopotools/RegressionData/raw/master/coweeta_output_CLASS.bil
+  - wget https://github.com/LSDtopotools/RegressionData/raw/master/coweeta_output_CLASS.hdr
+  - wget https://github.com/LSDtopotools/RegressionData/raw/master/coweeta_output_CURV.bil
+  - wget https://github.com/LSDtopotools/RegressionData/raw/master/coweeta_output_CURV.hdr
+  - wget https://github.com/LSDtopotools/RegressionData/raw/master/coweeta_output_PLFMCURV.bil
+  - wget https://github.com/LSDtopotools/RegressionData/raw/master/coweeta_output_PLFMCURV.hdr
+  - wget https://github.com/LSDtopotools/RegressionData/raw/master/coweeta_output_PROFCURV.bil
+  - wget https://github.com/LSDtopotools/RegressionData/raw/master/coweeta_output_PROFCURV.hdr
   - wget https://github.com/LSDtopotools/RegressionData/raw/master/coweeta_output_SLOPE.bil
   - wget https://github.com/LSDtopotools/RegressionData/raw/master/coweeta_output_SLOPE.hdr
+  - wget https://github.com/LSDtopotools/RegressionData/raw/master/coweeta_output_SMOOTH.bil
+  - wget https://github.com/LSDtopotools/RegressionData/raw/master/coweeta_output_SMOOTH.hdr
+  - wget https://github.com/LSDtopotools/RegressionData/raw/master/coweeta_output_TANCURV.bil
+  - wget https://github.com/LSDtopotools/RegressionData/raw/master/coweeta_output_TANCURV.hdr
   - cd ..
   - LSDTT_BasicMetrics fixtures/ coweeta.driver
-  - pytest
+  - pytest -v
 
 after_success:
   # Build the docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,23 @@ install:
   - cd conda-recipe
   - conda build lsdtopotools -c conda-forge
   - conda create -n lsdtt lsdtopotools -c conda-forge --use-local
+  # Needed to run the tests
+  - conda install git pip pytest numpy
+  - pip install git+https://github.com/mapbox/rasterio.git # this will be replaced by a conda install once version 1.0 is released next month
 
 # Activate the venv and run a driver
 script:
   - source activate lsdtt
-  - LSDTT_BasicMetrics
+  - cd tests/
+  - mkdir results
+  - cd fixtures
+  - wget https://github.com/LSDtopotools/ExampleTopoDatasets/raw/master/coweeta.bil
+  - wget wget https://github.com/LSDtopotools/ExampleTopoDatasets/raw/master/coweeta.hdr
+  -
+  -
+  - cd ..
+  - LSDTT_BasicMetrics fixtures/ coweeta.driver
+  - pytest
 
 after_success:
   # Build the docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,6 @@ script:
   - LSDTT_BasicMetrics
 
 after_success:
-  on:
-    branch: travis
   # Build the docs
   - pwd
   - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,12 @@ script:
   - cd conda-recipe
   - conda build lsdtopotools -c conda-forge
   - conda create -n lsdtt lsdtopotools -c conda-forge --use-local
-  - sudo ln -s /home/travis/miniconda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
+  # - sudo ln -s /home/travis/miniconda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
   # - cat ~/.bashrc
   # - echo ". /home/travis/miniconda/etc/profile.d/conda.sh" >> ~/.bashrc
   # - cat ~/.bashrc
-  - conda activate
-  - conda activate lsdtt
+  # - conda activate
+  - source activate lsdtt
   - LSDTT_BasicMetrics
 
 # script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,10 @@ script:
   - cd conda-recipe
   - conda build lsdtopotools -c conda-forge
   - conda create -n lsdtt lsdtopotools -c conda-forge --use-local
-  - cat ~/.bashrc
-  - echo ". /home/travis/miniconda/etc/profile.d/conda.sh" >> ~/.bashrc
-  - cat ~/.bashrc
+  - sudo ln -s /home/travis/miniconda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
+  # - cat ~/.bashrc
+  # - echo ". /home/travis/miniconda/etc/profile.d/conda.sh" >> ~/.bashrc
+  # - cat ~/.bashrc
   - conda activate
   - conda activate lsdtt
   - LSDTT_BasicMetrics

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,15 @@ branches:
     - travis
 
 script:
+
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - hash -r
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  # Useful for debugging any issues with conda
+  - conda info -a
   - conda install conda-build
   - cd conda-recipe
   - conda build lsdtopotools -c conda-forge

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ script:
   - cd conda-recipe
   - conda build lsdtopotools -c conda-forge
   - conda create -n lsdtt lsdtopotools -c conda-forge --use-local
+  - echo ". /home/travis/miniconda/etc/profile.d/conda.sh" >> ~/.bashrc
+  - conda activate
   - conda activate lsdtt
   - LSDTT_BasicMetrics
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,13 @@ install:
   - conda build lsdtopotools -c conda-forge
   - conda create -n lsdtt lsdtopotools -c conda-forge --use-local
   # Needed to run the tests
-  - conda install git pip pytest numpy
-  - conda config --add channels conda-forge
-  - conda install rasterio
+  - conda install git pip pytest #numpy
+  #- conda config --add channels conda-forge
+  #- conda install rasterio
+  - sudo add-apt-repository ppa:ubuntugis/ppa
+  - sudo apt-get update
+  - sudo apt-get install python-numpy gdal-bin libgdal-dev
+  - pip install rasterio
 
 # Activate the venv and run a driver
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,18 @@ language:
 compiler:
   - gcc
 
-# Blacklist
-branches:
-  only:
-    - travis
+# Install dependencies needed for docs
+addons:
+  apt:
+    packages:
+      - doxygen
+      - doxygen-doc
+      - doxygen-latex
+      - doxygen-gui
+      - graphviz
 
-script:
+# Use conda to install LSDTT and create a virual environment
+install:
 
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
@@ -18,39 +24,25 @@ script:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda update -q conda
-  # Useful for debugging any issues with conda
-  - conda info -a
   - conda install conda-build
   - cd conda-recipe
   - conda build lsdtopotools -c conda-forge
   - conda create -n lsdtt lsdtopotools -c conda-forge --use-local
-  # - sudo ln -s /home/travis/miniconda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
-  # - cat ~/.bashrc
-  # - echo ". /home/travis/miniconda/etc/profile.d/conda.sh" >> ~/.bashrc
-  # - cat ~/.bashrc
-  # - conda activate
+
+# Activate the venv and run a driver
+script:
   - source activate lsdtt
   - LSDTT_BasicMetrics
 
-# script:
-#   # Run your build commands next
-#   - sh build_docs.sh
-#
-# # Install dependencies
-# addons:
-#   apt:
-#     packages:
-#       - doxygen
-#       - doxygen-doc
-#       - doxygen-latex
-#       - doxygen-gui
-#       - graphviz
-#
-# # Deploy using travis builtin GitHub Pages support
-# deploy:
-#   provider: pages
-#   skip_cleanup: true
-#   local_dir: html/
-#   github_token: $GITHUB_API_KEY
-#   on:
-#     branch: master
+after_success:
+  # Build the docs
+  - sh build_docs.sh
+
+# Deploy using travis builtin GitHub Pages support - only for changes to master
+deploy:
+  provider: pages
+  skip_cleanup: true
+  local_dir: html/
+  github_token: $GITHUB_API_KEY
+  on:
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,9 @@ install:
   - conda install git pip pytest #numpy
   #- conda config --add channels conda-forge
   #- conda install rasterio
-  - sudo add-apt-repository ppa:ubuntugis/ppa
-  - sudo apt-get update
-  - sudo apt-get install python-numpy gdal-bin libgdal-dev
+  - sudo add-apt-repository ppa:ubuntugis/ppa -y
+  - sudo apt-get update -y
+  - sudo apt-get install python-numpy gdal-bin libgdal-dev -y
   - pip install rasterio
 
 # Activate the venv and run a driver

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,9 @@ script:
   - cd conda-recipe
   - conda build lsdtopotools -c conda-forge
   - conda create -n lsdtt lsdtopotools -c conda-forge --use-local
+  - cat ~/.bashrc
   - echo ". /home/travis/miniconda/etc/profile.d/conda.sh" >> ~/.bashrc
+  - cat ~/.bashrc
   - conda activate
   - conda activate lsdtt
   - LSDTT_BasicMetrics

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ addons:
 
 # Use conda to install LSDTT and create a virual environment
 install:
-
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
@@ -35,7 +34,11 @@ script:
   - LSDTT_BasicMetrics
 
 after_success:
+  on:
+    branch: travis
   # Build the docs
+  - pwd
+  - cd ..
   - sh build_docs.sh
 
 # Deploy using travis builtin GitHub Pages support - only for changes to master

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,12 +28,12 @@ install:
   - conda build lsdtopotools -c conda-forge
   - conda create -n lsdtt lsdtopotools -c conda-forge --use-local
   # Needed to run the tests
-  - conda install git pip pytest #numpy
+  - conda install git pip pytest numpy
   #- conda config --add channels conda-forge
   #- conda install rasterio
   - sudo add-apt-repository ppa:ubuntugis/ppa -y
   - sudo apt-get update -y
-  - sudo apt-get install python-numpy gdal-bin libgdal-dev -y
+  - sudo apt-get install gdal-bin libgdal-dev -y
   - pip install rasterio
 
 # Activate the venv and run a driver

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,30 +8,34 @@ compiler:
 # Blacklist
 branches:
   only:
-    - master
-
-before_install:
-  #- sudo apt-get install -y libfftw3-dev
+    - travis
 
 script:
-  # Run your build commands next
-  - sh build_docs.sh
+  - conda install conda-build
+  - cd conda-recipe
+  - conda build lsdtopotools -c conda-forge
+  - conda create -n lsdtt lsdtopotools -c conda-forge --use-local
+  - LSDTT_BasicMetrics
 
-# Install dependencies
-addons:
-  apt:
-    packages:
-      - doxygen
-      - doxygen-doc
-      - doxygen-latex
-      - doxygen-gui
-      - graphviz
-
-# Deploy using travis builtin GitHub Pages support
-deploy:
-  provider: pages
-  skip_cleanup: true
-  local_dir: html/
-  github_token: $GITHUB_API_KEY
-  on:
-    branch: master
+# script:
+#   # Run your build commands next
+#   - sh build_docs.sh
+#
+# # Install dependencies
+# addons:
+#   apt:
+#     packages:
+#       - doxygen
+#       - doxygen-doc
+#       - doxygen-latex
+#       - doxygen-gui
+#       - graphviz
+#
+# # Deploy using travis builtin GitHub Pages support
+# deploy:
+#   provider: pages
+#   skip_cleanup: true
+#   local_dir: html/
+#   github_token: $GITHUB_API_KEY
+#   on:
+#     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,8 @@ install:
   - conda create -n lsdtt lsdtopotools -c conda-forge --use-local
   # Needed to run the tests
   - conda install git pip pytest numpy
-  - pip install git+https://github.com/mapbox/rasterio.git # this will be replaced by a conda install once version 1.0 is released next month
+  - conda config --add channels conda-forge
+  - conda install rasterio
 
 # Activate the venv and run a driver
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ install:
   - conda create -n lsdtt lsdtopotools -c conda-forge --use-local
   # Needed to run the tests
   - conda install git pip pytest numpy
-  #- conda config --add channels conda-forge
-  #- conda install rasterio
+  # From the rasterio docs
   - sudo add-apt-repository ppa:ubuntugis/ppa -y
   - sudo apt-get update -y
   - sudo apt-get install gdal-bin libgdal-dev -y

--- a/build_docs.sh
+++ b/build_docs.sh
@@ -2,3 +2,4 @@
 rm -rf html/
 doxygen Doxyfile
 cp img/LSD-logo.png html/
+echo $?

--- a/tests/fixtures/coweeta.driver
+++ b/tests/fixtures/coweeta.driver
@@ -1,0 +1,11 @@
+read path: fixtures/
+write path: results/
+read fname: coweeta
+write fname: coweeta_output
+channel heads fname: NULL
+surface_fitting_radius: 20
+print_slope: true
+print_aspect: false
+print_curvature: false
+print_tangential_curvature: false
+write extension: bil

--- a/tests/fixtures/coweeta.driver
+++ b/tests/fixtures/coweeta.driver
@@ -5,7 +5,11 @@ write fname: coweeta_output
 channel heads fname: NULL
 surface_fitting_radius: 20
 print_slope: true
-print_aspect: false
-print_curvature: false
-print_tangential_curvature: false
 write extension: bil
+print_smoothed_elevation: true
+print_aspect: true
+print_curvature: true
+print_planform_curvature: true
+print_profile_curvature: true
+print_tangential_curvature: true
+print_point_classification: true

--- a/tests/fixtures/paths.json
+++ b/tests/fixtures/paths.json
@@ -1,0 +1,34 @@
+{
+  "aspect": {
+    "expected": "fixtures\/coweeta_output_ASPECT.bil",
+    "result": "results\/coweeta_output_ASPECT.bil"
+  },
+  "class": {
+    "expected": "fixtures\/coweeta_output_CLASS.bil",
+    "result": "results\/coweeta_output_CLASS.bil"
+  },
+  "curv": {
+    "expected": "fixtures\/coweeta_output_CURV.bil",
+    "result": "results\/coweeta_output_CURV.bil"
+  },
+  "plfmcurv": {
+    "expected": "fixtures\/coweeta_output_PLFMCURV.bil",
+    "result": "results\/coweeta_output_PLFMCURV.bil"
+  },
+  "profcurv": {
+    "expected": "fixtures\/coweeta_output_PROFCURV.bil",
+    "result": "results\/coweeta_output_PROFCURV.bil"
+  },
+  "slope": {
+    "expected": "fixtures\/coweeta_output_SLOPE.bil",
+    "result": "results\/coweeta_output_SLOPE.bil"
+  },
+  "smooth": {
+    "expected": "fixtures\/coweeta_output_SMOOTH.bil",
+    "result": "results\/coweeta_output_SMOOTH.bil"
+  },
+  "tancurv": {
+    "expected": "fixtures\/coweeta_output_TANCURV.bil",
+    "result": "results\/coweeta_output_TANCURV.bil"
+  }
+}

--- a/tests/test_slope.py
+++ b/tests/test_slope.py
@@ -1,0 +1,18 @@
+import pytest
+import rasterio
+
+@pytest.fixture
+def original_data():
+    out_data = rasterio.open('fixtures/coweeta.bil')
+    return out_data.read(1)
+
+
+@pytest.fixture
+def new_data():
+    out_data = rasterio.open('results/coweeta_output_SLOPE.bil')
+    return out_data.read(1)
+
+
+class TestingLSD():
+    def test_slope(self, original_data, new_data):
+        assert (original_data == new_data).all()

--- a/tests/test_slope.py
+++ b/tests/test_slope.py
@@ -31,4 +31,4 @@ def params():
 class TestingLSD():
     @pytest.mark.parametrize('result,expected', params())
     def test_basic_metrics(self, result, expected):
-        ntest.assert_allclose(result, expected)
+        ntest.assert_allclose(result, expected, rtol=1e-03)

--- a/tests/test_slope.py
+++ b/tests/test_slope.py
@@ -3,7 +3,7 @@ import rasterio
 
 @pytest.fixture
 def original_data():
-    out_data = rasterio.open('fixtures/coweeta.bil')
+    out_data = rasterio.open('fixtures/coweeta_output_SLOPE.bil')
     return out_data.read(1)
 
 

--- a/tests/test_slope.py
+++ b/tests/test_slope.py
@@ -1,6 +1,7 @@
 import pytest
 import json
 import rasterio
+import numpy.testing as ntest
 
 
 def raster(filename):
@@ -30,4 +31,4 @@ def params():
 class TestingLSD():
     @pytest.mark.parametrize('result,expected', params())
     def test_basic_metrics(self, result, expected):
-        assert (result == expected).all()
+        ntest.assert_allclose(result, expected)


### PR DESCRIPTION
A total redesign of the `travis.yml` config, which now builds on all branches and PRs using the conda installer. In addition to running the conda install, a regression test has been added which compares the content of a slope raster to a static file held in a [new repository]().

A driver file has been added which runs a minimal set of analyses, generating a slope raster to compare against the static version. The comparison between the output rasters is performed using pytest and rasterio and has been written in a way which will allow us to scale the number of such tests relatively easily, with minimal additional code.

These tests are distinct from unit tests which will be written using a c++ testing framework, but for these sorts of tests it was easier for me to prototype something in pytest.

On success, when changes are made to master, the new docs are deployed to the website.



